### PR TITLE
Reduce stack usage

### DIFF
--- a/ff_derive/src/pow_fixed.rs
+++ b/ff_derive/src/pow_fixed.rs
@@ -15,6 +15,7 @@ pub(crate) fn generate(
     exponent: BigUint,
 ) -> proc_macro2::TokenStream {
     let steps = build_addition_chain(exponent.clone());
+    // last_usage[i] indicates the last usage of the i-th temporary variable.
     let last_usage = steps.iter().enumerate().fold(Vec::new(), |mut acc, (n, step)| {
         acc.push(n);
         match step {
@@ -23,13 +24,21 @@ pub(crate) fn generate(
         }
         acc
     });
-    let mut drops: Vec<(usize, usize)> = last_usage.into_iter().enumerate().collect();
-    drops.sort_by_key(|(_i, last_usage)| *last_usage);
+    // drops is the ordered sequence of possible drops of the temporary variable
+    // the first component is the variable to drop, the second is when to drop it
+    let drops: Vec<(usize, usize)> = {
+        let mut drops: Vec<(usize, usize)> = last_usage.into_iter().enumerate().collect();
+        drops.sort_by_key(|(_i, last_usage)| *last_usage);
+        drops
+    };
 
     let mut gen = proc_macro2::TokenStream::new();
 
+    // contains all idents that can be reused
     let mut free_idents: Vec<Ident> = Vec::new();
+    // the number of variables that have been used so far.
     let mut n_vars = 0usize;
+    // give code for using a free variable, and the corresponding ident
     fn get_free_variable(v: &mut Vec<Ident>, n_vars: &mut usize) -> (proc_macro2::TokenStream, Ident) {
         if let Some(last) = v.pop() {
             (quote! { #last }, last)
@@ -43,12 +52,14 @@ pub(crate) fn generate(
     // First entry in chain is one, i.e. the base.
     let (start_code, start) = get_free_variable(&mut free_idents, &mut n_vars);
     gen.extend(quote! {
-        #start_code = *#base;
+        #start_code = *#base; // the asterisk makes it work
     });
 
     let mut tmps = vec![start];
+    // current location in drops
     let mut drop_index = 0usize;
     for (i, step) in steps.into_iter().enumerate() {
+        // allow reuse of everything that will be dropped in this instruction
         while drop_index < drops.len() && drops[drop_index].1 <= i {
             free_idents.push(tmps[drops[drop_index].0].clone());
             drop_index += 1;


### PR DESCRIPTION
This is solving the following problem: in https://github.com/elusiv-privacy/arcium-tooling/actions/runs/11791848630/job/32844542445, during `Test CLI building examples - mxe mvp`, the following error happened without causing CI crash:

```
Error: Function _ZN90_$LT$arcis..utils..field..scalar_field..field_derive..ScalarField$u20$as$u20$ff..Field$GT$6invert17h30f6eb1bc4dd88d5E Stack offset of 8104 exceeded max offset of 4096 by 4008 bytes, please minimize large stack variables
Error: Function _ZN90_$LT$arcis..utils..field..scalar_field..field_derive..ScalarField$u20$as$u20$ff..Field$GT$4sqrt17hc3d5b5015da3e324E Stack offset of 8560 exceeded max offset of 4096 by 4464 bytes, please minimize large stack variables
Error: Function _ZN86_$LT$arcis..utils..field..base_field..field_derive..BaseField$u20$as$u20$ff..Field$GT$6invert17hb13c294b444b4612E Stack offset of 8232 exceeded max offset of 4096 by 4136 bytes, please minimize large stack variables
Error: Function _ZN86_$LT$arcis..utils..field..base_field..field_derive..BaseField$u20$as$u20$ff..Field$GT$4sqrt17h6dc83aa5a8ccc87eE Stack offset of 8224 exceeded max offset of 4096 by 4128 bytes, please minimize large stack variables
```
The issue was that the power-computing function was using too many temporary variables.

This PR fixes the issue by reusing temporary variables.
